### PR TITLE
Ignore pushes to private branches

### DIFF
--- a/base-config.yaml
+++ b/base-config.yaml
@@ -227,6 +227,7 @@ messages:
         {% endif %}
 
     push: >
+        {% if util.ref_is_personal(ref) %} {% do abort() %} {% endif %}
         {{ templates.repo_sender_prefix }}
         {% if forced %}force{% endif %}
         {% if deleted %}deleted {{ util.ref_type(ref) }}

--- a/github/template/util.py
+++ b/github/template/util.py
@@ -55,6 +55,13 @@ class TemplateUtil:
         return ref.split("/", 2)[2]
 
     @staticmethod
+    def ref_is_personal(ref: str) -> bool:
+        # Detect personal branches
+        # return True if branch name contains '/', like in
+        #     "refs/heads/username/some-branch"
+        return '/' in ref.split("/", 2)[2]
+
+    @staticmethod
     def join_human_list(data: List[str], *, joiner: str = ", ", final_joiner: str = " and ",
                         mutate: Callable[[str], str] = lambda val: val) -> str:
         if not data:

--- a/maubot.yaml
+++ b/maubot.yaml
@@ -1,6 +1,6 @@
 maubot: 0.4.1
 id: xyz.maubot.github
-version: 0.2.0
+version: 0.2.1
 license: AGPL-3.0-or-later
 modules:
 - github


### PR DESCRIPTION
If ref is in format "username/feature" then ignore the event to avoid spamming.